### PR TITLE
Change request body size from 1MB (default) to 50MB

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,6 +1,7 @@
 server {
     listen 80;
     server_name ieee.nitk.ac.in;
+    client_max_body_size 50M;
 
     location / {
         return 301 https://$host$request_uri;
@@ -10,6 +11,8 @@ server {
 server {
     listen 443 ssl;
     server_name ieee.nitk.ac.in;
+    client_max_body_size 50M;
+
 
     ssl_certificate /etc/letsencrypt/live/ieee.nitk.ac.in/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/ieee.nitk.ac.in/privkey.pem;


### PR DESCRIPTION
# Description

By default, nginx has a request body size limit of 1MB. This is problematic when users wish to upload profile pictures that are larger than 1MB or submit Rich Text Content which may go larger than 1MB.

Thus the constraint has been raised to 50MB

Fixes # (issue)

## Dependencies

List any dependencies that are required for this change.

## Type of Change

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration. (for bug fix / breaking change)
_Put an `x` in the boxes that apply_

- [ ] Test A
- [ ] Test B

---

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
