### PR TITLE
Fixed #208 :  Password reset input CSS issue

### DIFF
--- a/corpus/templates/registration/password_reset_form.html
+++ b/corpus/templates/registration/password_reset_form.html
@@ -8,29 +8,6 @@
 <div class="card w-3/4 lg:w-1/3 mx-auto my-10 bg-base-200 shadow-xl">
     <div class="card-body">
         <h1 class="card-title text-2xl">Reset Password</h1>
-        <style>
-            .card-body input[type="email"] {
-                box-sizing: border-box;
-                width: 100%;
-                padding: 10px 12px;
-                border: 1px solid #cfcfcf;
-                border-radius: 8px;
-                background: #ffffff;
-                color: #0b0b0b;
-                outline: none;
-                font-size: 1rem;
-            }
-
-            .card-body input[type="email"]:focus {
-                box-shadow: 0 0 0 3px rgba(59,130,246,0.12);
-                border-color: #3b82f6;
-            }
-
-            .card-body label {
-                display: block;
-                margin-bottom: 0.4rem;
-            }
-        </style>
 
         <form method="post">
             {% csrf_token %}
@@ -64,4 +41,28 @@
         </form>
     </div>
 </div>
+        <style>
+            .card-body input[type="email"] {
+                box-sizing: border-box;
+                width: 100%;
+                padding: 10px 12px;
+                border: 1px solid #cfcfcf;
+                border-radius: 8px;
+                background: #ffffff;
+                color: #0b0b0b;
+                outline: none;
+                font-size: 1rem;
+            }
+
+            .card-body input[type="email"]:focus {
+                box-shadow: 0 0 0 3px rgba(59,130,246,0.12);
+                border-color: #3b82f6;
+            }
+
+            .card-body label {
+                display: block;
+                margin-bottom: 0.4rem;
+            }
+        </style>
+
 {% endblock %}


### PR DESCRIPTION
# Description

Fixed a CSS issue where the email input on the Password Reset page had invisible text due to theme overrides.
The input inherited a dark background and dark text from the global theme, making typed text unreadable.

A minimal, scoped inline CSS override was added to ensure the input has a white background, black text, proper padding, and visible borders , without modifying Docker-generated Tailwind files.

Fixes #208

## Dependencies

No new dependencies added.

## Type of Change

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
_Put an `x` in the boxes that apply_

- [x] Manually tested on the Password Reset page
- [x] Verified that the login page and other forms remain unaffected
- [x] Tested inside Docker environment with fresh rebuild

---

## Checklist

_Put an `x` in the boxes that apply._

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<hr> PFA screenshots of fixed issue below 

<img width="1920" height="1080" alt="Screenshot from 2025-12-07 12-59-27" src="https://github.com/user-attachments/assets/7bb1f612-5471-453e-a9bb-34cd0235145f" />
<img width="1920" height="1080" alt="Screenshot from 2025-12-07 12-59-21" src="https://github.com/user-attachments/assets/3d48666e-ecb0-47e1-bba8-b20bfb143c4f" />

