### PR TITLE
Mentee to Mentor Program Creation Bug Fix

### DIFF
--- a/corpus/smp/mentor_views.py
+++ b/corpus/smp/mentor_views.py
@@ -54,12 +54,14 @@ def dashboard(request):
 @ensure_exec_membership()
 def new_program(request):
 
-    existing_program = Program.objects.filter(
-        programmember__member=request.user
-    ).first()
+    # Check whether the user is already a Mentor in any program.
+    # If they were only a Mentee in previous years, this will not block them.
+    already_mentor = ProgramMember.objects.filter(
+        member=request.user, member_type="Mentor"
+    ).exists()
 
-    if existing_program:
-        messages.info(request, "You have already have a program.")
+    if already_mentor:
+        messages.info(request, "You already have a program.")
         return redirect("smp_mentors_dashboard")
 
     form = ProgramForm()


### PR DESCRIPTION
# Description

Earlier each Executive Member could be a member and mentor in only one SMP program while the mentees could be in several programs. However the logic did not take into account that some of the 1st year mentees would become Executive members in their 2nd years, thus creating a new program as a mentor this time was throwing Execption to prevent Executive mebers from being in more than one SMP. 

Simple fix done to check if the user requesting to create a new Program has any past programs as a Mentor. If not allow creation of program.

Fixes #314 

## Dependencies

List any dependencies that are required for this change.

## Type of Change

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration. (for bug fix / breaking change)
_Put an `x` in the boxes that apply_

- [ ] Test A
- [ ] Test B

---

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
